### PR TITLE
Issue #55: Create a dashboard for current projects

### DIFF
--- a/_data/projects/active.yml
+++ b/_data/projects/active.yml
@@ -1,32 +1,72 @@
 -
-  name: Cliff Effects (with Project Hope)
-  url: https://github.com/codeforboston/project-hope
+  name: Cliff Effects
+  elevatorPitch: >
+    This tool can help show how a change in income affects 
+    how much someone receives in public assistance 
+    from SNAP and Section 8 Housing Voucher benefits. 
+    It was designed for the case managers at Project 
+    Hope with the aim of helping to predict changes 
+    in their clients' benefits.
+  url: https://codeforboston.github.io/cliff-effects/
+  repository: https://github.com/codeforboston/cliff-effects
+  partner: Project Hope
+  partnerUrl: http://www.prohope.org/
+  lead: A wonderful person
+  leadUrl: http://wonderfulperson.com
+  technologies: NodeJS, ReactJS
   news: >
-   **User testing was a success! Now we need to:**
-    * Discuss and implement changes needed from user feedback and create a better user experience
-    * Write unit, regression, and integration tests
-    * Strengthen our existing code and make it more maintainable
-    * Examine legislative documentation with people experienced with reading policy to check the validity of our benefit program calculations
+    User testing was a success! Now we need to:
+    <ul>
+      <li>Discuss and implement changes needed from user feedback and create a better user experience</li>
+      <li>Write unit, regression, and integration tests</li>
+      <li>Strengthen our existing code and make it more maintainable</li>
+      <li>Examine legislative documentation with people experienced with reading policy to check the validity of our benefit program calculations</li>
 -
   name: My City Voice App
-  url: https://github.com/codeforboston/voiceapp311
+  elevatorPitch: >
+    An Alexa skill to answer questions about municipal 
+    services in Boston. Currently supports providing an 
+    address and asking for trash/recycling pick up days.
+  repository: https://github.com/codeforboston/voiceapp311
+  partner: City of Boston 311
+  partnerUrl: https://www.cityofboston.gov/311/
+  lead: Another wonderful person
+  leadUrl: http://wonderfulperson.com
+  technologies: Python, AWS
   news: >
-    Technologies: Python, AWS
-
-    * Updating data locations for trash day and snow parking
-    * Researching automated testing
-    * Developing new Alexa features
-      * Street sweeping days
-      * City of Boston status page
+    <ul>
+      <li>Updating data locations for trash day and snow parking</li>
+      <li>Researching automated testing</li>
+      <li>Developing new Alexa features</li>
+      <li>Street sweeping days</li>
+      <li>City of Boston status page</li>
+    </ul>
 -
   name: Interactive Film Documentary
-  news: >
+  elevatorPitch: > 
     Code and UI/UX for the invisible women of Delhi
-    React Native -- need support building around the YouTube API. 
-    media: <iframe height="520px" width="1600" src="https://www.youtube.com/embed/SWXhe6ycKrY" frameborder="10" data-autoplay allowfullscreen></iframe>
+  url: https://www.youtube.com/watch?v=SWXhe6ycKrY
+  repository: 
+  partner: 
+  partnerUrl: 
+  lead: Anandana Kapur
+  leadUrl: 
+  technologies: React Native, YouTube API
+  news: >
+    Need help integrating with the YouTube API
+  # What to do with this media?
+  # <iframe height="520px" width="1600" src="https://www.youtube.com/embed/SWXhe6ycKrY" frameborder="10" data-autoplay allowfullscreen></iframe>
 -
   name: MuckRock
+  elevatorPitch: >
+    File, track, and share public records requests.
   url: https://www.muckrock.com/
+  repository: https://github.com/MuckRock/muckrock
+  partner: 
+  partnerUrl: 
+  lead: 
+  leadUrl: 
+  technologies: Python, Django
   news: >
     MuckRock is a non-profit, collaborative news site that brings together journalists,
     researchers, activists, and regular citizens to request, analyze, and share government

--- a/css/main.scss
+++ b/css/main.scss
@@ -52,7 +52,41 @@ $on-laptop:        800px;
     }
 }
 
+// Custom Classes for codeforamerica.org
 
+.project {
+    padding: 10px; 
+    border-color:black; 
+    border-width: 1px; 
+    border-style: solid; 
+    background-color: #f5f5f5;
+}
+
+.em {
+    font-style: italic;
+}
+
+.small {
+    font-size: 80%;
+}
+
+.elevatorPitch {
+    line-height: 1.25;
+    @extend .small;
+    @extend .em;
+}
+
+.spacer-0 {
+    margin-bottom: 0px;
+}
+
+.spacer-10 {
+    margin-bottom: 10px;
+}
+
+.spacer-30 {
+    margin-bottom: 30px;
+}
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import

--- a/projects.html
+++ b/projects.html
@@ -7,13 +7,95 @@ type: inNavBar
 
 <h1 class="t-section-headline">Projects</h1>
 <section>
+    <h2 class="spacer-0">Current Projects</h2>
+    <div>
+            <p>The following initiatives are currently underway and 
+                accepting contributors. Projects 
+            are open to volunteers of all skillsets - if you're interested, just show up 
+            at one of our 
+            <a href="{{site.meetup_url}}">Tuesday evening hack nights!</a>!</p>
+    </div>
+    <div class="container">
+        {% for proj in site.data.projects.active %}
+        <div class="row project">
+            <div class="col-3">
+                <div class="row">
+                    <div class="col-12">
+                        {% if proj.url %}<a href="{{proj.url}}" target="project">{% endif %}
+                            <h3>{{proj.name}}</h3>
+                        {% if proj.url %}</a>{% endif %}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-12 elevatorPitch">
+                        {{proj.elevatorPitch}}
+                    </div>
+                </div>
+            </div>
+            <div class="col-9">
+                {% if proj.repository %}
+                <div class="row">
+                    <div class="col-4">
+                        <strong>Code Repository</strong>
+                    </div>
+                    <div class="col-8">
+                        <a href="{{proj.repository}}" target="project">{{proj.repository}}</a>
+                    </div>
+                </div>
+                {% endif %}
+                <div class="row">
+                    <div class="col-4">
+                        <strong>Technologies Used</strong>
+                    </div>
+                    <div class="col-8">
+                        {{proj.technologies}}
+                    </div>
+                </div>
+                {% if proj.partner %}
+                <div class="row">
+                    <div class="col-4">
+                        <strong>Partner Organization</strong>
+                    </div>
+                    <div class="col-8">
+                        {% if proj.partnerUrl %}<a href="{{proj.partnerUrl}}" target="project">{% endif %}
+                            {{proj.partner}}
+                        {% if proj.partnerUrl %}</a>{% endif %}
+                    </div>
+                </div>
+                {% endif %}
+                {% if proj.lead %}
+                <div class="row">
+                    <div class="col-4">
+                        <strong>Lead</strong>
+                    </div>
+                    <div class="col-8">
+                        {% if proj.leadUrl %}<a href="{{proj.leadUrl}}" target="project">{% endif %}
+                            {{proj.lead}}
+                        {% if proj.leadUrl %}</a>{% endif %} 
+                    </div>
+                </div>
+                {% endif %}
+                <div class="row spacer-10">
+                    <div class="col-12"></div>
+                </div>
+                <div class="row">
+                    <div class="col-12">
+                        <small>{{proj.news}}</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row spacer-30">
+            <div class="col-12"></div>
+        </div>
+        
+        {% endfor %}
+    </div>
+</section>
+
+<section>
     <h2 class="">Past Projects</h2>
     {% for proj in site.data.projects.inactive %}
-        <a class="btn-secondary btn--small" href="{{proj.url}}">{{ proj.name }}</a>
-    {% endfor %}
-    <h2 class="">Open Projects</h2>
-    <p>Here is a sample of what we've been working on recently. Projects are open to all volunteers - if you're interested, just show up at one of our <a href="{{site.meetup_url}}">Tuesday evening hack nights!</a></p>
-    {% for proj in site.data.projects.active %}
         <a class="btn-secondary btn--small" href="{{proj.url}}">{{ proj.name }}</a>
     {% endfor %}
     <p>You can view all the projects we've ever done (in code) over on <a href="{{site.github_url}}">github</a>.</p>

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,22 @@ LiveReload address: http://127.0.0.1:35729
 - To add/update jobs, edit [`_data/jobs.yml`](https://github.com/codeforboston/CFB_static/edit/master/_data/jobs.yml)
 - To add/update events, edit [`_data/events/active.yml`](https://github.com/codeforboston/CFB_static/edit/master/_data/events/active.yml)
 - To add/update current projects, edit [`_data/projects/active.yml`](https://github.com/codeforboston/CFB_static/edit/master/_data/projects/active.yml)
+
+Current projects are displayed on the Dashboard at `http://www.codeforboston.org/projects`.  To encourage contribution both in their initatives and CFB, project leads are encouraged to regularly update the backing data with relevant status updates alongside each Meetup.  To do this, simply edit the data fields in the file indicated above and submit a PR to the site's authoritative repository at [https://github.com/codeforboston/codeforboston.org](https://github.com/codeforboston/codeforboston.org).  The following fields are supported:
+
+|Field Name|Description|
+|---|---|
+|`name`|Name of the project (required)|
+|`elevatorPitch`|Short blurb, 1-2 sentences, explaining the project's mission (required)|
+|`url`|URL of the project home page|
+|`repository`|URL of the project's code repository (GitHub, required)|
+|`partner`|Name of the organization acting as partner for this initiative|
+|`partnerUrl`|URL to the partner's home page|
+|`lead`|Name of the project lead|
+|`leadUrl`|URL to contact the project lead, either a page with contact info or a `mailto://` protocol URL|
+|`technologies`|List of technologies used, ie "Java, NodeJS, React, etc."|
+|`news`|Weekly summary of tasks needed and progress made.  Should ideally entice and motivate contributors to get involved.  A good place to post project needs as a request for volunteers.|
+
 - To add/update retired projects, edit [`_data/projects/inactive.yml`](https://github.com/codeforboston/CFB_static/edit/master/_data/projects/inactive.yml)
 - To edit normal site pages, edit the `html` or `markdown` files in `_pages/`
 - To edit the homepage content, edit `index.html`


### PR DESCRIPTION
See attached commit.

This page is intended to provide a one-stop dashboard of all active projects in the brigade and their current statuses.  By editing and submitting PRs to this site's _`data/projects/active.yml` file, project leads and maintainers may easily update the dashboard on codeforboston.org.

It's my hope this will serve to better encourage new contributors and lower the barrier to entry for volunteering.

I also expect that after this first round we may offer iterative improvements by asking the projects which fields they'd like to add to the dashboard and how they might best be able to use this.

As far as the design proposed in this PR goes, this is what the page currently looks like:

![before](https://user-images.githubusercontent.com/199891/43183800-6098a6f0-8fb4-11e8-9475-686b513fe49a.png)

This PR applies the following changes to make the page look like this:

![after](https://user-images.githubusercontent.com/199891/43183812-6df1ac48-8fb4-11e8-94a7-2284f2483e57.png)

