### PR TITLE
Add centered class width for page layout on desktop

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -87,6 +87,7 @@ h3 {
 }
 
 .centered {
+    width: 50em;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 250px;


### PR DESCRIPTION
This pull request addresses the lack of padding on the left and right of content on all pages of the site. The content of each page now sits with padding on the left and ride side of all containers with the `.centered` class. 

This PR fixes issue #70.

Before:
![image](https://user-images.githubusercontent.com/9803215/52608969-a22f2600-2e49-11e9-8ff6-1c8a52b67295.png)

After:
![image](https://user-images.githubusercontent.com/9803215/52608960-95aacd80-2e49-11e9-89ec-bd9cdb28e8d7.png)
 