### PR TITLE
Correct Footer Behavior on Desktop and Mobile

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,12 +3,12 @@
   <div class="container">
       <div class="row">
           <div class="col-12 col-md-4 p-3 ">
-            <h2>Contact</h2>
+            <h3>Contact</h3>
               <a href="mailto:{{ site.email }}">{{ site.email }}</a>
           </div>
 
           <div class="col-12 col-md-4 p-3">
-            <h2>Collaborate</h2>
+            <h3>Collaborate</h3>
               <a href="https://docs.google.com/forms/d/e/1FAIpQLSce0lWiZFMe4HnqgM9iaXDVhpwG06_GNLGKKYR2mcQGlhQ4rQ/viewform">
                 Submit a project idea </a><br>
               <a href="/projects">
@@ -16,7 +16,7 @@
           </div>
 
           <div class="col-12 col-md-4 p-3">
-            <h2>Connect</h2>
+            <h3>Connect</h3>
             <a href="{{site.github_url}}">
                   GitHub </a><br />
             <a href="{{ site.twitter_url }}">

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -61,7 +61,6 @@ a {
 .site-footer {
     padding: $spacing-unit 0;
     background: $grey-color-light;
-    position: relative;
     margin-top: 6rem;
     padding-top: 3rem;
     color: $black-color;

--- a/css/main.scss
+++ b/css/main.scss
@@ -49,7 +49,6 @@ body {
   position: relative;
   margin: 0;
   padding-bottom: 12rem;
-  min-height: 100%;
 }
 
 html {
@@ -83,13 +82,13 @@ h3 {
 }
 
 .page-content {
-    margin-bottom: 300px;
+    margin-bottom: 50px;
 }
 
 .centered {
     margin-left: auto;
     margin-right: auto;
-    margin-bottom: 250px;
+    margin-bottom: 50px;
     padding: 10px;
 }
 
@@ -132,12 +131,12 @@ h3 {
 /*** FOOTER ***/
 
 .site-footer {
+    border-top: 5px solid #65B3E0;
     background: #e8e8e8;
-    position: fixed;
+    padding: 20px 0px 20px 0px;
     color: #111;
     box-sizing: border-box;
     right: 0;
-    bottom: 0;
     left: 0;
 }
 


### PR DESCRIPTION
Previously, the footer of this site would overlap body content on the main page. While on traditional desktop browsers, this did not create a serious problem, the mobile experience was difficult to navigate (see #77). This PR addresses the behavior of the site and the footer in both desktop and mobile viewports, and closes #77.

| iPhone 6/7/8 Viewport | iPhone 6/7/8 Viewport |
|-------|-------|
| ![footer_top](https://user-images.githubusercontent.com/9803215/52918672-af279b80-32c7-11e9-9469-1f9ad4ff2a1a.png) | ![footer_bottom](https://user-images.githubusercontent.com/9803215/52918676-b64ea980-32c7-11e9-9e37-633e7b4ecd64.png) |

See the appearance of the footer on desktop - it no longer overlays the body content of the site, but is easily available upon scrolling. 

**Desktop Footer**
![127 0 0 1_4000_ laptop](https://user-images.githubusercontent.com/9803215/52918683-d2eae180-32c7-11e9-84c4-237b5e2f8591.png)