### PR TITLE
Update hangout link for My City project

### DIFF
--- a/_data/projects/active.yml
+++ b/_data/projects/active.yml
@@ -11,7 +11,7 @@
   lead: Jamie Martini
   technologies: Python, AWS
   slackChannel: mycity
-  hangoutsSlug: bostoninfo
+  hangoutsSlug: mycity
 -
   name: MuckRock
   elevatorPitch: >


### PR DESCRIPTION
The Google Meet name for the My City project was changed from `bostoninfo` to `mycity`. This patch updates this link on the  project info page.