### PR TITLE
General link maintenance.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,18 +19,20 @@ description:
   to solve civic and social problems.'
 baseurl: ''
 url: https://www.codeforboston.org
+# NOTE:If you change the below donate_url you should also update the URL here: https://github.com/codeforboston/.github/FUNDING.yml
+donate_url: https://codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Boston&utm_source=codeforboston.org
 hackpad_url: https://codeforboston.hackpad.com/
 twitter_url: https://twitter.com/codeforboston
 github_url: https://github.com/codeforboston
 meetup_url: https://meetup.com/Code-For-Boston
 blog_url: https://medium.com/@CodeForBoston
-events_url: http://cal.codeforboston.org
+events_url: https://cal.codeforboston.org
 zoom_url: https://codeforamerica.zoom.us/meeting/register/tJwpdO2hpj8qE9VQwzZGNMduNOXb-GNLcNY0
-slack_url: https://communityinviter.com/apps/cfb-public/code-for-boston
+slack_url: https://communityinviter.com/apps/cfb-public/code-for-boston-slack-invite
 youtube_url: https://www.youtube.com/c/codeforboston
 facebook_url: https://www.facebook.com/codeforboston/
 instagram_url: https://www.instagram.com/codeforboston/
-newsletter_url: http://eepurl.com/5UcLX
+newsletter_url: https://eepurl.com/5UcLX
 slack_team_id: T0556DP9Y
 plugins:
   - jekyll-redirect-from

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,7 @@
             {% endif %} {% endfor %}
             <li>
               <a
-                href="https://www.codeforamerica.org/donate-to-a-brigade"
+                href="{{ site.donate_url }}"
                 class="btn-primary btn--small"
               >
                 Donate

--- a/_includes/pages-list.html
+++ b/_includes/pages-list.html
@@ -10,7 +10,7 @@
         {% endfor %}
 
 	    <li>
-            <a href="https://www.codeforamerica.org/donate-to-a-brigade" class="btn-primary btn--small">Donate</a>
+            <a href="{{ site.donate_url }}" class="btn-primary btn--small">Donate</a>
         </li>
 
     </ul>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ layout: default
   <div class="btn-group">
     <a href="{{ site.zoom_url }}" class="btn-secondary">RSVP on Zoom</a>
     <a
-      href="https://communityinviter.com/apps/cfb-public/code-for-boston-slack-invite"
+      href="{{ site.slack_url }}"
       class="btn-secondary"
       >Say hi on Slack</a
     >


### PR DESCRIPTION
-Eliminated some URL duplication by replacing hardcoded donate links with a donate_url variable in config.yml.

-Added a note about modifying donate_url that points future maintainers to the sponsorship link in: .github/FUNDING.yml

-Replaced a few hardcoded links from http:// to https://

-Fixed a slack invite link issue where CfB logo doesn't load on invite page.