### PR TITLE
Use the slack channel name

### DIFF
--- a/_data/projects/active.yml
+++ b/_data/projects/active.yml
@@ -1,12 +1,12 @@
 - name: Harvard FCU Map
   elevatorPitch: >
-    HFCU was recently charted as a federal credit union. This change has expanded those eligible for membership in the HFCU to include those living in census tracts that are considered underserved by traditional banks.  This project is focused in making it easier for someone interested in membership to determine if they live in one of these census tracts and eligible to join.  
+    HFCU was recently charted as a federal credit union. This change has expanded those eligible for membership in the HFCU to include those living in census tracts that are considered underserved by traditional banks.  This project is focused in making it easier for someone interested in membership to determine if they live in one of these census tracts and eligible to join.
   repository: https://github.com/codeforboston/harvard-fcu
   partner:
     - name: Harvard Federal Credit Union
       url: https://harvardfcu.org
   lead: Annie LaCourt
-  slackChannel: hfcu
+  slackChannel: harvard-fcu
 - name: Home Energy Analysis Tool
   elevatorPitch: >
     Residential heating accounts for over 15% of greenhouse gas emissions in Massachusetts. Transitioning from fossil-fuel heating systems to heat pumps is a key step in the state's overall decarbonization strategy, but appropriately sizing heat pumps is critical to realizing their full decarbonization benefit. This project involves moving a calculator tool from an Excel spreadsheet into a web application to improve the workflow of volunteer Heat Pump Coaches and later make the tool more accessible to the public.


### PR DESCRIPTION
Updates the harvard-fcu slack channel for #168 

The maple and NPDC slack links look correct and go to the slack channels.

Screenshot shows the updated slack link

<img width="910" alt="Screenshot 2025-03-19 at 2 15 21 PM" src="https://github.com/user-attachments/assets/4815dbb3-bb43-4348-a41f-e60695d22952" />
